### PR TITLE
feat: allow different minSdkVersion

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -29,7 +29,7 @@ def getExtOrIntegerDefault(name) {
 android {
   compileSdkVersion getExtOrIntegerDefault('compileSdkVersion')
   defaultConfig {
-    minSdkVersion 26
+    minSdkVersion getExtOrIntegerDefault('minSdkVersion')
     targetSdkVersion getExtOrIntegerDefault('targetSdkVersion')
     versionCode 1
     versionName "1.0"

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,3 +1,4 @@
 RecordScreen_kotlinVersion=1.3.50
 RecordScreen_compileSdkVersion=29
 RecordScreen_targetSdkVersion=29
+RecordScreen_minSdkVersion=26


### PR DESCRIPTION
Hi


Is there a reason the minSdkVersion is at 26? When I look at [HBRecorder](https://github.com/HBiSoft/HBRecorder) the min API level is 21.

This PR allows the minSdkVersion field to be overridden.