### PR TITLE
docs(android): remove non existing android.permission.WRITE_INTERNAL_STORAGE

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ npx pod-install
 
 ```xml
 <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
-<uses-permission android:name="android.permission.WRITE_INTERNAL_STORAGE" />
 <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 <!-- If you intend to use the microphone -->
 <uses-permission android:name="android.permission.RECORD_AUDIO" />

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -2,7 +2,6 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
-    <uses-permission android:name="android.permission.WRITE_INTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <!-- If you intend to use the microphone -->
     <uses-permission android:name="android.permission.RECORD_AUDIO" />


### PR DESCRIPTION
A small mistake in the docs. There is no such thing as `android.permission.WRITE_INTERNAL_STORAGE`.

An app can always write to the app storage, which is a good option to store a screen capture.